### PR TITLE
Atualiza Estatistica Oracle

### DIFF
--- a/Atualizar_estatistica_Oracle.sql
+++ b/Atualizar_estatistica_Oracle.sql
@@ -1,0 +1,19 @@
+declare 
+v_tb varchar2(300);
+begin
+ for stale in (select * from DBA_TAB_STATISTICS where STALE_STATS = 'YES' and owner = 'OWNER' -- and num_rows <10000000 
+ ) loop 
+	 --v_tb := stale.table_name;
+	 DBMS_OUTPUT.PUT_LINE('Iniciando processo em ' || stale.table_name );
+	 DBMS_STATS.GATHER_TABLE_STATS(OWNNAME=>  stale.owner   , TABNAME=>  stale.table_name  , ESTIMATE_PERCENT=>20);
+	 
+	 DBMS_OUTPUT.PUT_LINE('Finalizado ' || stale.table_name);
+	 DBMS_OUTPUT.PUT_LINE('------------------------------------');
+ end loop;
+ 
+ EXCEPTION
+ 	when OTHERS then 
+ 	DBMS_OUTPUT.PUT_LINE('Houve erro');
+ 
+ 
+end;


### PR DESCRIPTION
Script para atualização de estatística em base de dados Oracle. Esta efetuando a atualiza de um owner especifico, porem pode ser adaptado para realizar de todos os owners, uma tabela e etc.